### PR TITLE
test: Fix issues with AWS EC2 ComputeService Mock

### DIFF
--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2ComputeServiceApiMockTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2ComputeServiceApiMockTest.java
@@ -35,7 +35,7 @@ public class AWSEC2ComputeServiceApiMockTest extends BaseAWSEC2ApiMockTest {
 
    protected String getDefaultSmallestInstanceType() {
       // NOT t2.xxx because that requires a VPC
-      return "m3.medium";
+      return "t3.nano";
    }
      
    protected String getDefaultParavirtualInstanceType() {
@@ -44,7 +44,7 @@ public class AWSEC2ComputeServiceApiMockTest extends BaseAWSEC2ApiMockTest {
    }
 
    protected String getDefaultImageId() {
-       return "be3adfd7";
+       return "7ea24a17";
    }
    
    public void launchVPCSpotInstanceSubnetId() throws Exception {


### PR DESCRIPTION
 - Smallest size is t3.nano now
 - Default image id updated